### PR TITLE
🍱 Move content from the `lamin-static` repo here

### DIFF
--- a/.github/workflows/latest-changes.jinja2
+++ b/.github/workflows/latest-changes.jinja2
@@ -1,2 +1,2 @@
-{{pr.title}} | [{{pr.number}}]({{pr.html_url}}) | [{{pr.user.login}}]({{pr.user.html_url}}) | {{pr.closed_at.date().isoformat()}} |
+{{pr.title}} | [{{pr.number}}]({{pr.html_url}}) | [{{pr.user.login}}]({{pr.user.html_url}}) | {{pr.closed_at.date().isoformat()}}
 

--- a/.github/workflows/latest-changes.yml
+++ b/.github/workflows/latest-changes.yml
@@ -21,5 +21,5 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           latest_changes_file: docs/changelog.md
-          latest_changes_header: '--- \| --- \| --- \| --- \| ---\n'
+          latest_changes_header: '--- \| --- \| --- \| --- \n'
           template_file: ./.github/workflows/latest-changes.jinja2

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Lamin Legal
 
-The site is served at [lamin.ai](https://legal.lamin.ai).
+The site is served at [legal.lamin.ai](https://legal.lamin.ai).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,5 @@
 # Changelog
 
 <!-- prettier-ignore -->
-Name | PR | Editor | Date | Number
---- | --- | --- | --- | ---
+Name | PR | Editor | Date
+--- | --- | --- | ---

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,30 +1,28 @@
 import sys
 from pathlib import Path
-from dirsync import sync
 
 HERE = Path(__file__).parent
 sys.path[:0] = [str(HERE), str(HERE.parent)]
 
 from lamin_sphinx import *  # noqa
-from lamin_sphinx import html_theme_options  # noqa
+from lamin_sphinx import html_theme_options, html_context  # noqa
 
-sync("../lamin-about/about", ".", "sync", exclude=["^.*README.md$"])
+project = "Lamin Legal"
+html_title = f"{project}"
+html_context["github_repo"] = "lamin-legal"  # noqa
 
-project = "Lamin"
-html_title = "Company | Lamin"
-html_context["github_repo"] = "lamin-about"  # noqa
-
-ogp_site_url = "https://lamin.ai"
+ogp_site_url = "https://legal.lamin.ai"
+ogp_site_name = project
 
 html_theme_options["logo"] = {
-    "link": "https://lamin.ai",
+    "link": "/",
     "text": project,
-    "root": "https://lamin.ai",
+    "root": "https://legal.lamin.ai",
 }
 html_theme_options["icon_links"] = [
     {
         "name": "GitHub",
-        "url": "https://github.com/laminlabs/lamin-about",
+        "url": "https://github.com/laminlabs/lamin-legal",
         "icon": "fa-brands fa-github",
     },
 ]

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,9 +1,9 @@
-# Lamin
+# Lamin Legal
 
 ```{toctree}
-:hidden: true
 :maxdepth: 1
 
 privacy-policy
 terms
+changelog
 ```

--- a/docs/terms.md
+++ b/docs/terms.md
@@ -22,7 +22,7 @@ Lamin operates the lamin.ai website, which provides
 
 By using our service (LaminHub) you accept these Terms. If you disagree with these Terms, you must not use our Service.
 
-In using our service, we may process your personal data; more information about this can be found in the [privacy policy](/legal/privacy-policy).
+In using our service, we may process your personal data; more information about this can be found in the [privacy policy](/privacy-policy).
 
 ## Subscriptions
 
@@ -46,7 +46,7 @@ Where our Service contains links to other sites, User Content, and resources pro
 
 ## Stored data
 
-For privacy-related data, see the [privacy policy](/legal/privacy-policy).
+For privacy-related data, see the [privacy policy](/privacy-policy).
 
 If you create a "LaminDB instance" and decide to "register it on lamin.ai", we store:
 


### PR DESCRIPTION
Moving was actually done in the initial commit; the direct parent, this here only fixes the build.